### PR TITLE
Update forms.py

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -327,12 +327,10 @@ class BaseSignupForm(_base_signup_form_class()):
 
 
 class SignupForm(BaseSignupForm):
-
-    password1 = PasswordField(label=_("Password"))
-    password2 = PasswordField(label=_("Password (again)"))
-
     def __init__(self, *args, **kwargs):
         super(SignupForm, self).__init__(*args, **kwargs)
+        self.fields['password1'] = PasswordField(label=_("Password"))
+        self.fields['password2'] = PasswordField(label=_("Password (again)"))
         if not app_settings.SIGNUP_PASSWORD_ENTER_TWICE:
             del self.fields["password2"]
 


### PR DESCRIPTION
Modified SignupForm and moved declaration of passwords inside __init__ method. The call to super() in __init__ places the password fields before any fields added in the __init__ of BaseSignupForm (e.g. email2) which is an undesired behaviour. The alternative is to have email2 in BaseSignupForm declared in __new__ (which might have other side effects).